### PR TITLE
Fix incorrect country names

### DIFF
--- a/lib/flagpack.ex
+++ b/lib/flagpack.ex
@@ -8883,7 +8883,7 @@ defmodule Flagpack do
   end
 
   @doc """
-  Renders the Phillippines (the) flag.
+  Renders the Philippines (the) flag.
 
   ## Examples
       <Flagpack.phl />
@@ -9681,7 +9681,7 @@ defmodule Flagpack do
   end
 
   @doc """
-  Renders the South Gerogia and the South Sandwich Islands flag.
+  Renders the South Georgia and the South Sandwich Islands flag.
 
   ## Examples
       <Flagpack.sgs />

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -171,7 +171,7 @@ defmodule Flagpack.Helpers do
     },
     %{country_name: "Greece", alpha2: "GR", alpha3: "GRC", numeric: "300"},
     %{
-      country_name: "South Gerogia and the South Sandwich Islands",
+      country_name: "South Georgia and the South Sandwich Islands",
       alpha2: "GS",
       alpha3: "SGS",
       numeric: "239"
@@ -333,7 +333,7 @@ defmodule Flagpack.Helpers do
       numeric: "598"
     },
     %{
-      country_name: "Phillippines (the)",
+      country_name: "Philippines (the)",
       alpha2: "PH",
       alpha3: "PHL",
       numeric: "608"


### PR DESCRIPTION
Found via `typos --hidden --format brief`

- https://en.wikipedia.org/wiki/Philippines
- https://en.wikipedia.org/wiki/South_Georgia_and_the_South_Sandwich_Islands
